### PR TITLE
Remove utf-8 encoding declarations

### DIFF
--- a/src/compute_mean_climatology.py
+++ b/src/compute_mean_climatology.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import datetime
 import os
 import pickle

--- a/src/generate_antarctica_today_map.py
+++ b/src/generate_antarctica_today_map.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
 Created on Mon Jan  4 16:18:05 2021
 

--- a/src/generate_gap_filled_melt_picklefile.py
+++ b/src/generate_gap_filled_melt_picklefile.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Code for generating the gap-filled melt array picklefile.
 Putting this inside of melt_array_picklefile.py caused circular-dependency issues since it uses
 a function from compute_mean_climatology, which uses functions from melt_array_picklefile. So,

--- a/src/line_smooth.py
+++ b/src/line_smooth.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
 Created on Fri Feb 19 17:09:37 2021
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
 Created on Sun Feb  7 08:51:25 2021
 

--- a/src/map_filedata.py
+++ b/src/map_filedata.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 import cartopy

--- a/src/melt_array_picklefile.py
+++ b/src/melt_array_picklefile.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
 Created on Mon Jan 25 15:03:31 2021
 

--- a/src/plot_daily_melt_and_climatology.py
+++ b/src/plot_daily_melt_and_climatology.py
@@ -3,7 +3,6 @@
 @author: mmacferrin
 """
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 import datetime
 import os

--- a/src/progress_bar.py
+++ b/src/progress_bar.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
 Created on Wed Oct 14 16:32:25 2020
 

--- a/src/read_NSIDC_bin_file.py
+++ b/src/read_NSIDC_bin_file.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Created on Fri Feb 21 15:03:50 2020
 

--- a/src/scalebar.py
+++ b/src/scalebar.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # The majority of this code was copy/pasted and then slightly adjusted from:
 # https://stackoverflow.com/questions/32333870/how-can-i-show-a-km-ruler-on-a-cartopy-matplotlib-plot
 # ...on Jan 15, 2021.

--- a/src/src_baseline/compute_ice_masks.py
+++ b/src/src_baseline/compute_ice_masks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Created on Thu Apr 30 15:12:42 2020
 

--- a/src/src_baseline/extract_gridded_RCM_data.py
+++ b/src/src_baseline/extract_gridded_RCM_data.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Created on Mon Apr  6 15:21:04 2020
 

--- a/src/src_baseline/extrapolate_thermap_readings_off_map_edge.py
+++ b/src/src_baseline/extrapolate_thermap_readings_off_map_edge.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Created on Tue May  5 12:25:44 2020
 

--- a/src/src_baseline/plot_thermap_lapse_rate.py
+++ b/src/src_baseline/plot_thermap_lapse_rate.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import numpy
 import pandas as pd
 import statsmodels.api as sm

--- a/src/src_baseline/resize_25m_grid_by_1000.py
+++ b/src/src_baseline/resize_25m_grid_by_1000.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Created on Tue May  5 09:47:38 2020
 

--- a/src/src_baseline/resize_grid_to_reference.py
+++ b/src/src_baseline/resize_grid_to_reference.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Created on Fri Apr 17 16:13:01 2020
 

--- a/src/src_baseline/sample_REMA_elevations.py
+++ b/src/src_baseline/sample_REMA_elevations.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Quick utility to read (and plot) elevations of Thermap sample points from the REMA DEM.
 
 import os

--- a/src/src_baseline/tb_create_grid_file.py
+++ b/src/src_baseline/tb_create_grid_file.py
@@ -1,5 +1,4 @@
 """Create a simple gridded file (every 10,50,100 pixels) to overlay in QGIS and easily visualize grid coordinates."""
-# -*- coding: utf-8 -*-
 
 
 import numpy

--- a/src/svgclip.py
+++ b/src/svgclip.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 
 """
 svgclip.py

--- a/src/tb_file_data.py
+++ b/src/tb_file_data.py
@@ -5,7 +5,6 @@ Code for keeping track of Tb-based model result data, and other products
 @author: mmacferrin
 """
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 import os
 

--- a/src/update_data.py
+++ b/src/update_data.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """Scripts for importing new NSIDC brightness-temperature data into the Antarctic melt database.
 
 Created by: mmacferrin

--- a/src/write_NSIDC_bin_to_gtif.py
+++ b/src/write_NSIDC_bin_to_gtif.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Created on Mon Apr  6 15:21:04 2020
 

--- a/src/write_flat_binary.py
+++ b/src/write_flat_binary.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Created on Fri Apr 17 13:38:32 2020
 


### PR DESCRIPTION
`utf-8` is the default encoding for Python 3, so we don't need these anymore :)

## PR checklist

- [x] Has a descriptive title
- [x] Has a descriptive body
- [x] Passes checks (to auto-fix a pre-commit.ci failure, add a comment
      containing "pre-commit.ci autofix")
