### PR TITLE
Fix numpy dtype deprecation errors

### DIFF
--- a/antarctica_today/compute_mean_climatology.py
+++ b/antarctica_today/compute_mean_climatology.py
@@ -113,7 +113,7 @@ def compute_daily_climatology_pixel_averages(
     # Generate an empty MxNxT array with
     average_melt_array = numpy.zeros(
         (melt_array.shape[0], melt_array.shape[1], len(baseline_filler_dt_list)),
-        dtype=numpy.float,
+        dtype=float,
     )
 
     # Now, compute the average odds (0-1) of melt on any given day for any given pixel, over the baseline period.
@@ -123,7 +123,7 @@ def compute_daily_climatology_pixel_averages(
                 ((dt.month == bdt.month) and (dt.day == bdt.day))
                 for dt in dt_list_melt_season
             ],
-            dtype=numpy.bool,
+            dtype=bool,
         )
         # # print ("\t", [dt for i,dt in enumerate(dt_list_melt_season) if bdt_day_mask[i]])
         # if numpy.count_nonzero(bdt_day_mask) == 0:
@@ -286,9 +286,7 @@ def create_baseline_climatology_tif(
     num_years = int((end_date - start_date).days / 365.25)
     # print(num_years)
 
-    annual_sum_grids = numpy.empty(
-        model_array.shape[0:2] + (num_years,), dtype=numpy.int
-    )
+    annual_sum_grids = numpy.empty(model_array.shape[0:2] + (num_years,), dtype=int)
 
     if gap_filled:
         model_melt_days = model_array
@@ -308,7 +306,7 @@ def create_baseline_climatology_tif(
         # print(i, dt1, dt2)
 
         dates_mask = numpy.array(
-            [(dt >= dt1) & (dt <= dt2) for dt in datetimes], dtype=numpy.bool
+            [(dt >= dt1) & (dt <= dt2) for dt in datetimes], dtype=bool
         )
 
         # dt1_i = datetimes.index(dt1)
@@ -320,8 +318,8 @@ def create_baseline_climatology_tif(
     annual_std_array = numpy.std(annual_sum_grids, axis=2, dtype=numpy.float32)
 
     if round_to_integers:
-        annual_mean_array = numpy.array(numpy.round(annual_mean_array), dtype=numpy.int)
-        annual_std_array = numpy.array(numpy.round(annual_std_array), dtype=numpy.int)
+        annual_mean_array = numpy.array(numpy.round(annual_mean_array), dtype=int)
+        annual_std_array = numpy.array(numpy.round(annual_std_array), dtype=int)
 
     annual_mean_array[(ice_mask == 0)] = -1
     annual_std_array[(ice_mask == 0)] = -1
@@ -382,7 +380,7 @@ def create_partial_year_melt_anomaly_tif(
             ((dt >= first_dt_of_present_melt_season) and (dt <= current_datetime))
             for dt in dt_list
         ],
-        dtype=numpy.bool,
+        dtype=bool,
     )
     dts_masked = [dt for dt, mask_val in zip(dt_list, dt_mask) if mask_val]
 
@@ -592,7 +590,7 @@ def create_annual_melt_sum_tif(
 
         dates_mask = numpy.array(
             [((dt >= start_date) and (dt <= end_date)) for dt in dt_list],
-            dtype=numpy.bool,
+            dtype=bool,
         )
 
         # Skip any years for which there is no data.
@@ -602,13 +600,13 @@ def create_annual_melt_sum_tif(
         if gap_filled:
             # First add the floating-point values
             melt_array_year = numpy.sum(
-                melt_array[:, :, dates_mask], axis=2, dtype=numpy.float
+                melt_array[:, :, dates_mask], axis=2, dtype=float
             )
             # Round to integers
-            melt_array_year = numpy.array(melt_array_year.round(), dtype=numpy.int)
+            melt_array_year = numpy.array(melt_array_year.round(), dtype=int)
         else:
             melt_array_year = numpy.sum(
-                (melt_array[:, :, dates_mask] == 2), axis=2, dtype=numpy.int
+                (melt_array[:, :, dates_mask] == 2), axis=2, dtype=int
             )
 
         melt_array_year[ice_mask == 0] = -1

--- a/antarctica_today/generate_antarctica_today_map.py
+++ b/antarctica_today/generate_antarctica_today_map.py
@@ -916,7 +916,7 @@ class AT_map_generator:
 
         Return None if no date found.
         """
-        match = re.search("\d{8}", filename)
+        match = re.search(r"\d{8}", os.path.basename(filename))
         if match is None:
             return None
 
@@ -1724,7 +1724,7 @@ class AT_map_generator:
 
             if mmdd_of_year is not None:
                 datetime_of_year = datetime.datetime(
-                    year=(y + 1) if (tuple(mmdd_of_year) < tuple(melt_end_mmdd)) else y,
+                    year=(y + 1) if (tuple(mmdd_of_year) <= tuple(melt_end_mmdd)) else y,
                     month=mmdd_of_year[0],
                     day=mmdd_of_year[1],
                 )

--- a/antarctica_today/generate_gap_filled_melt_picklefile.py
+++ b/antarctica_today/generate_gap_filled_melt_picklefile.py
@@ -73,7 +73,7 @@ def fill_melt_array_with_interpolations(array=None, datetimes_dict=None, verbose
     # print("\t",gap_filled_dt_list[0], gap_filled_dt_list[-1], len(gap_filled_dt_list))
 
     gap_filled_array = numpy.empty(
-        (array.shape[0], array.shape[1], len(gap_filled_dt_list)), dtype=numpy.float
+        (array.shape[0], array.shape[1], len(gap_filled_dt_list)), dtype=float
     )
 
     for gap_i, dt in enumerate(gap_filled_dt_list):

--- a/antarctica_today/line_smooth.py
+++ b/antarctica_today/line_smooth.py
@@ -37,7 +37,7 @@ def line_smooth(y, window_size, method="linear"):
     elif method == "gaussian":
         # Make mu (mean) the middle of the window, and sigma one half of one-half
         # the length (giving it a distrigbution of 2 sigmas on either side of mu).
-        x = numpy.arange(ws, dtype=numpy.float)
+        x = numpy.arange(ws, dtype=float)
         mu = float(int(ws / 2))
         sig = int(ws / 2) / 2.0  # The two divisions are purposeful.
         # If for some stupid reasion they pick a window-size of one, make sure the function doesn't break.

--- a/antarctica_today/map_filedata.py
+++ b/antarctica_today/map_filedata.py
@@ -42,12 +42,12 @@ anomaly_maps_directory = os.path.join(
 
 # A shapefile containing a vector outline for each region, separately. The {0} region just contains them all.
 region_outline_shapefiles_dict: dict[int, Path] = {
-    0: DATA_QGIS_DIR / "Antarctic_Regions_v2.shp",
-    1: DATA_QGIS_DIR / "Antarctic_Regions_v2_R1.shp",
-    2: DATA_QGIS_DIR / "Antarctic_Regions_v2_R2.shp",
-    3: DATA_QGIS_DIR / "Antarctic_Regions_v2_R3.shp",
-    4: DATA_QGIS_DIR / "Antarctic_Regions_v2_R4.shp",
-    5: DATA_QGIS_DIR / "Antarctic_Regions_v2_R5.shp",
-    6: DATA_QGIS_DIR / "Antarctic_Regions_v2_R6.shp",
-    7: DATA_QGIS_DIR / "Antarctic_Regions_v2_R7.shp",
+    0: DATA_QGIS_DIR / "basins" / "Antarctic_Regions_v2.shp",
+    1: DATA_QGIS_DIR / "basins" / "Antarctic_Regions_v2_R1.shp",
+    2: DATA_QGIS_DIR / "basins" / "Antarctic_Regions_v2_R2.shp",
+    3: DATA_QGIS_DIR / "basins" / "Antarctic_Regions_v2_R3.shp",
+    4: DATA_QGIS_DIR / "basins" / "Antarctic_Regions_v2_R4.shp",
+    5: DATA_QGIS_DIR / "basins" / "Antarctic_Regions_v2_R5.shp",
+    6: DATA_QGIS_DIR / "basins" / "Antarctic_Regions_v2_R6.shp",
+    7: DATA_QGIS_DIR / "basins" / "Antarctic_Regions_v2_R7.shp",
 }

--- a/antarctica_today/melt_array_picklefile.py
+++ b/antarctica_today/melt_array_picklefile.py
@@ -211,7 +211,7 @@ def get_datetimes_from_file_list(file_dir=model_results_dir, return_as_dict=Fals
 
     dt_list = [None] * len(file_list)
     for i, fpath in enumerate(file_list):
-        search_result = re.search("(?<=_)\d{8}(?=_)", os.path.split(fpath)[-1])
+        search_result = re.search(r"(?<=_)\d{8}(?=_)", os.path.split(fpath)[-1])
         if search_result is None:
             raise ValueError(
                 "Unrecognized file", fpath + ", cannot extract date from file name."
@@ -232,7 +232,15 @@ def get_datetimes_from_file_list(file_dir=model_results_dir, return_as_dict=Fals
 
 
 def _filter_out_erroneous_swaths(model_array, datetimes_dict):
-    """Nullify particular false-positive satellite swaths in the data."""
+    """Nullify particular false-positive satellite swaths in the data.
+
+    These are hand-outlined to nullify data (primarily from the 1980s) in which the satellite was
+    giving false-positive readings and producing melt extents that were unreasonable and ficticious.
+
+    We outline those regions and set false "melt" (2) values to "no data" (0).
+
+    Later, the gap-filling routine will fill these in with probable values for those days.
+    """
     try:
         # 1985-02-19
         array_slice = model_array[

--- a/antarctica_today/read_NSIDC_bin_file.py
+++ b/antarctica_today/read_NSIDC_bin_file.py
@@ -78,7 +78,6 @@ def read_NSIDC_bin_file(
     # If the file is meant to be an integer array, just return it.
     if return_type in (
         int,
-        numpy.int,
         numpy.uint8,
         numpy.int8,
         numpy.uint16,

--- a/antarctica_today/write_NSIDC_bin_to_gtif.py
+++ b/antarctica_today/write_NSIDC_bin_to_gtif.py
@@ -14,14 +14,14 @@ from read_NSIDC_bin_file import read_NSIDC_bin_file
 # See https://nsidc.org/data/polar-stereo/ps_grids.html for documentation on
 # these polar stereo grids
 # Upper-left corners of the grids, in km, in x,y
-NSIDC_S_GRID_UPPER_LEFT_KM = numpy.array((-3950, 4350), dtype=numpy.int)
-NSIDC_N_GRID_UPPER_LEFT_KM = numpy.array((-3850, 5850), dtype=numpy.int)
+NSIDC_S_GRID_UPPER_LEFT_KM = numpy.array((-3950, 4350), dtype=int)
+NSIDC_N_GRID_UPPER_LEFT_KM = numpy.array((-3850, 5850), dtype=int)
 # Pixel dimensions of the respective grids, in (y,x) --> (rows, cols)
 GRIDSIZE_25_N = numpy.array(
-    ((5850 + 5350) / 25, (3750 + 3850) / 25), dtype=numpy.long
+    ((5850 + 5350) / 25, (3750 + 3850) / 25), dtype=int
 )  # (448, 304)
 GRIDSIZE_25_S = numpy.array(
-    ((4350 + 3950) / 25, (3950 + 3950) / 25), dtype=numpy.long
+    ((4350 + 3950) / 25, (3950 + 3950) / 25), dtype=int
 )  # (332, 316)
 GRIDSIZE_12_5_N = GRIDSIZE_25_N * 2  # (896, 608)
 GRIDSIZE_12_5_S = GRIDSIZE_25_S * 2  # (664, 632)

--- a/antarctica_today/write_NSIDC_bin_to_gtif.py
+++ b/antarctica_today/write_NSIDC_bin_to_gtif.py
@@ -11,6 +11,9 @@ import numpy
 from osgeo import gdal, osr
 from read_NSIDC_bin_file import read_NSIDC_bin_file
 
+# To be forward-compatible with future GDAL versions, and to stop it from tossing a User Warning every time this runs.
+osr.UseExceptions()
+
 # See https://nsidc.org/data/polar-stereo/ps_grids.html for documentation on
 # these polar stereo grids
 # Upper-left corners of the grids, in km, in x,y

--- a/environment.yml
+++ b/environment.yml
@@ -12,13 +12,11 @@ dependencies:
   - earthaccess ~=0.6.1
   - gdal ~=3.5
   - pandas ~=1.4
+  - numpy ~=1.26.2
   - geopandas ~=0.14.0
   - cartopy ~=0.21.0
   - python-dateutil ~=2.8
   - pillow ~=9.2
-
-  ## Need a numpy version before np.int was deprecated:
-  - numpy ~=1.19.4
 
   ## Currently, numpy's pin keeps Xarray back at v2022.09
   - xarray


### PR DESCRIPTION
    Fixing deprecated usages of old numpy dtypes.
    
    Removed references to:
    - "numpy.int" and "numpy.long" (replaced by "int"),
    - "numpy.float" (replaced by "float")
    - "numpy.bool" (replaced by "bool")
    
    References to specific type sizes (e.g. "numpy.float32" or "numpy.int16") are not deprecated, and remain in place.
    Removed the requirement in environmental.yaml to suggest older versions of numpy, for which this deprecated code didn't break things. This code should now be compatible with the latest versions of numpy (as of this commit).


## PR checklist

- [x] Has a descriptive title
- [x] Has a descriptive body
- [x] Passes checks (to auto-fix a pre-commit.ci failure, add a comment
      containing "pre-commit.ci autofix")
