### PR TITLE
Improve data updates and plot generation

### DIFF
--- a/Tb/nsidc-0080/.gitignore
+++ b/Tb/nsidc-0080/.gitignore
@@ -2,3 +2,5 @@
 *
 # Except this file
 !.gitignore
+*.nc
+*.bin

--- a/antarctica_today/generate_plots_for_given_day.py
+++ b/antarctica_today/generate_plots_for_given_day.py
@@ -1,0 +1,203 @@
+"""
+Written by: Mike MacFerrin, 2023.12.13 (original version)
+"""
+
+import argparse
+import datetime
+import dateutil.parser
+import matplotlib.pyplot
+import os
+import re
+import shutil
+
+from antarctica_today import (
+    generate_daily_melt_file,
+    generate_antarctica_today_map,
+    tb_file_data,
+    plot_daily_melt_and_climatology,
+    map_filedata
+)
+
+def generate_maps_and_plots_for_a_date(
+    dt: datetime.datetime,
+    region="ALL",
+    dpi: int=300,
+    copy_to_gathered_dir: bool=True,
+    ):
+    """Generate 3 maps and one line-plot for a given date.
+    
+    If a region number is given (0-7), produce them just for that region. If 'ALL', produce them for all the regions.
+    Plots will be placed in their respective sub-directories under /plots.
+    
+    If copy_to_gathered_dir, after plots are produced for that day, put them in the "/plots/daily_plots_gathered"
+    sub-directory (under a sub-dir matching that date) for easy fetching.
+    
+    This function does not do any of the processing for a given date nor update the database. For that, use
+    the update_data.py script.
+    """
+    # QA the "region" parameter
+    if type(region) is str:
+        if region.strip().upper() == "ALL":
+            region = "ALL"
+        else:
+            # Convert to an integer. If it's already an integer (or float) this will work already.
+            # If it's something else, it'll error-out usefully (the message to the user will probably be useful).
+            region = int(region)
+
+    if region == "ALL":
+        regions = list(range(0,8))
+    else:
+        assert type(region) == int and 0 <= region <= 7
+        regions = [region]
+
+    date_message = "through " + dt.strftime("%d %b %Y").lstrip("0")
+    year = generate_daily_melt_file.get_melt_year_of_current_date(dt)
+    mapper = generate_antarctica_today_map.AT_map_generator()
+
+    for region_num in regions:
+        mapper.generate_annual_melt_map(
+            year=year,
+            region_number=region_num,
+            mmdd_of_year=(dt.month, dt.day),
+            dpi=dpi,
+            message_below_year=date_message
+        )
+
+        mapper.generate_anomaly_melt_map(
+            year=year,
+            mmdd_of_year=(dt.month, dt.day),
+            dpi=dpi,
+            region_number=region_num,
+            message_below_year=date_message + "\nrelative to 1990-2020 average",
+        )
+
+        # Find the daily melt .bin file for this particular day, to create the daily melt map for that day.
+        daily_dir = tb_file_data.model_results_dir
+        matching_binfiles = \
+            [os.path.join(daily_dir, fname)
+                for fname in os.listdir(daily_dir) if
+                fname.find("antarctica_melt_" + dt.strftime("%Y%m%d")) == 0 and os.path.splitext(fname)[1] == ".bin"
+            ]
+        # We really should only find one melt .bin file for that particular day.
+        assert len(matching_binfiles) <= 1
+        # Only generate a map if we've found a file for it.
+        if len(matching_binfiles) == 1:
+            mapper.generate_daily_melt_map(
+                infile=matching_binfiles[0], outfile="auto", region_number=region_num, dpi=dpi
+            )
+
+        lineplot_outfile = os.path.join(
+            tb_file_data.climatology_plots_directory,
+            "R{0}_{1}-{2}_{3}_gap_filled.png".format(
+                region_num, year, year + 1, dt.strftime("%Y.%m.%d")
+            ),
+        )
+
+        plot_daily_melt_and_climatology.plot_current_year_melt_over_baseline_stats(
+            current_date=dt,
+            region_num=region_num,
+            gap_filled=True,
+            dpi=dpi,
+            outfile=lineplot_outfile,
+            verbose=True,
+        )
+
+        # Close the current plots open in matplotlib. (Keeps them from accumulating.)
+        matplotlib.pyplot.close("all")
+
+    if copy_to_gathered_dir:
+        """After running the 'update_everything_to_latest_date()' function, use this to gather all the
+        latest-date plots into one location. Put it in a sub-directory of the daily_plots_gathered_dir
+        with all the latest plots just made."""
+
+        # Get latest file from melt anomaly directory. Also, get the date we're computing up to.
+        date_string = dt.strftime("%Y.%m.%d")
+        if region == "ALL":
+            search_str = "R[0-7]_{0}-{1}_{2}".format(year, year + 1, date_string) + r"(\w)*\.png\Z"
+        else:
+            search_str = "R{3}_{0}-{1}_{2}".format(year, year + 1, date_string, region) + r"(\w)*\.png\Z"
+
+        # Get all the files that match our search string. May be different dates and possibly different regions.
+
+        # daily_melt_maps_dir = map_filedata.daily_maps_directory,
+        # sum_maps_dir = map_filedata.annual_maps_directory,
+        # anomaly_maps_dir = map_filedata.anomaly_maps_directory,
+        # line_plots_dir = tb_file_data.climatology_plots_directory
+
+        files_in_anomaly_maps_dir = [
+            os.path.join(map_filedata.anomaly_maps_directory, fn)
+            for fn in os.listdir(map_filedata.anomaly_maps_directory)
+            if re.search(search_str, fn) is not None
+        ]
+        files_in_sum_maps_dir = [
+            os.path.join(map_filedata.annual_maps_directory, fn)
+            for fn in os.listdir(map_filedata.annual_maps_directory)
+            if re.search(search_str, fn) is not None
+        ]
+
+        # The daily maps don't list the melt year, so we use a slightly different search string for those.
+        daily_search_str = "R[0-7]_{0}_daily.png".format(date_string)
+        files_in_daily_maps_dir = [
+            os.path.join(map_filedata.daily_maps_directory, fn)
+            for fn in os.listdir(map_filedata.daily_maps_directory)
+            if re.search(daily_search_str, fn) is not None
+        ]
+        files_in_line_plots_dir = [
+            os.path.join(tb_file_data.climatology_plots_directory, fn)
+            for fn in os.listdir(tb_file_data.climatology_plots_directory)
+            if re.search(search_str, fn) is not None
+        ]
+
+        files_to_move = (
+                files_in_anomaly_maps_dir
+                + files_in_sum_maps_dir
+                + files_in_daily_maps_dir
+                + files_in_line_plots_dir
+        )
+
+        date_string = dt.strftime("%Y.%m.%d")
+        # If the sub-directory with this latest date doesn't exist, create it.
+        dest_dir_location = os.path.join(tb_file_data.daily_plots_gathered_dir, date_string)
+        if not os.path.exists(dest_dir_location):
+            os.mkdir(dest_dir_location)
+            print("Created directory '{0}'.".format(dest_dir_location))
+
+        for fn in files_to_move:
+            src = fn
+            dst = os.path.join(dest_dir_location, os.path.basename(fn))
+            if os.path.exists(dst) and os.path.exists(src):
+                os.remove(dst)
+
+            shutil.copyfile(src, dst)
+
+            print("{0} -> {1}.".format(src, dst))
+
+
+def define_and_parse_args():
+    parser = argparse.ArgumentParser("Produce all plots for the season on a particular date. Does not download any new"
+                                     " data or update the database, just produces the plots and maps.")
+    parser.add_argument("DATE", type=str, help="A date in a format readable by the python dateutil.parser module."
+                                               "YYYY-MM-DD suffices."
+                                               "Date should be within the melt season from 01 Oct thru 30 Apr."
+                                               "Behavior is undefined for dates outside that melt-season range.")
+    parser.add_argument("-region", "-r", default="ALL",
+                        help="Generate for a specific Antarctic region (0-7), or 'ALL'. Default 'ALL' will produce all"
+                             "regions 0 (Antarctic continent) and 1-7 (or each sub-region).")
+    parser.add_argument("-dpi", "-d", type=int, default=300, help="DPI of output figures (in PNG format)."
+                                                                               " Default 300.")
+    parser.add_argument("--gather", "--g", default=False, action="store_true",
+                        help="Copy all plots produced into a dated sub-dir of the plots/daily_plots_gathered for easy"
+                        "fetching after execution.")
+
+    return parser.parse_args()
+
+if __name__ == "__main__":
+    args = define_and_parse_args()
+    this_dt = dateutil.parser.parse(args.DATE)
+
+    generate_maps_and_plots_for_a_date(
+        this_dt,
+        region=args.region,
+        dpi=args.dpi,
+        copy_to_gathered_dir=args.gather
+    )

--- a/antarctica_today/read_NSIDC_bin_file.py
+++ b/antarctica_today/read_NSIDC_bin_file.py
@@ -53,7 +53,7 @@ def read_NSIDC_bin_file(
     # Check to make sure the data is the right size, raise ValueError if not.
     # TODO: The NSIDC-0051 data has the rows,cols in the header. We could read it from there,
     # although right now we just get the grid size from the parameter.
-    if int(len(raw_data) / element_size) != int(numpy.product(grid_shape)):
+    if int(len(raw_data) / element_size) != int(numpy.prod(grid_shape)):
         raise ValueError(
             "File {0} has {1} elements, does not match grid size {2}.".format(
                 fname, int(len(raw_data) / element_size), str(grid_shape)

--- a/antarctica_today/tb_file_data.py
+++ b/antarctica_today/tb_file_data.py
@@ -57,7 +57,7 @@ antarctic_regions_dict = {
     4: "Amery and Shackleton",
     5: "Wilkes and Adelie",
     6: "Ross Embayment",
-    7: "Amundsen Bellinghausen",
+    7: "Amundsen Bellingshausen",
 }
 
 NSIDC_0080_file_dir = DATA_TB_DIR / "nsidc-0080"

--- a/antarctica_today/update_data.py
+++ b/antarctica_today/update_data.py
@@ -373,10 +373,13 @@ def update_everything_to_latest_date(
         matplotlib.pyplot.close('all')
 
     # Then, if specified, make copies of all the files in the "daily_plots_gathered" directory for easy reference.
+    # It turns out we don't want to use Symlinks here. Posting these files online can get squirreley when we're using
+    # simlinks rather than actual files.
     if copy_to_gathered_dir:
         copy_latest_date_plots_to_date_directory(
             year=generate_daily_melt_file.get_melt_year_of_current_date(dt_today),
             date=latest_date,
+            use_symlinks=False
         )
 
     # Return the updated arrays, if wanted.
@@ -395,7 +398,7 @@ def copy_latest_date_plots_to_date_directory(
     line_plots_dir=tb_file_data.climatology_plots_directory,
     use_symlinks=True,
     verbose=True,
-):
+    ):
     """After running the 'update_everything_to_latest_date()' function, use this to gather all the
     latest-date plots into one location. Put it in a sub-directory of the daily_plots_gathered_dir
     with all the latest plots just made."""

--- a/antarctica_today/update_data.py
+++ b/antarctica_today/update_data.py
@@ -118,13 +118,11 @@ def update_everything_to_latest_date(
     if start_time <= dt_today:
         # Download all Tb files, starting with the day
         # after the last date in the present array.
-    # TODO: RE-activate this line after fixing bugs below.
-        pass
-        # download_new_files(
-        #     time_start=start_time_str,
-        #     time_end=dt_today.strftime("%Y-%m-%d"),
-        #     only_in_melt_season=melt_season_only,
-        # )
+        download_new_files(
+            time_start=start_time_str,
+            time_end=dt_today.strftime("%Y-%m-%d"),
+            only_in_melt_season=melt_season_only,
+        )
 
     # # Ignore the .xml files, only get a list of the .bin files we downloaded.
     # tb_file_list = [fname for fname in tb_file_list if os.path.splitext(fname)[-1].lower() == ".bin"]

--- a/antarctica_today/update_data.py
+++ b/antarctica_today/update_data.py
@@ -4,6 +4,7 @@ Created by: mmacferrin
 2021.04.08
 """
 import datetime
+import matplotlib.pyplot
 import os
 import pickle
 import re
@@ -319,7 +320,7 @@ def update_everything_to_latest_date(
         save_daily_melt_numbers_to_csv(gap_filled=True)
 
         # Also snag what the current melt-year value is, for the maps below.
-        year = generate_daily_melt_file.get_melt_year_of_current_date(daily_dts[-1])
+        year = generate_daily_melt_file.get_melt_year_of_current_date(new_daily_dts[-1])
 
     else:
         year = generate_daily_melt_file.get_melt_year_of_current_date(
@@ -367,6 +368,9 @@ def update_everything_to_latest_date(
             outfile=line_plot_outfile,
             verbose=True,
         )
+
+        # Clear the figures just made above in order to not get too many open at once.
+        matplotlib.pyplot.close('all')
 
     # Then, if specified, make copies of all the files in the "daily_plots_gathered" directory for easy reference.
     if copy_to_gathered_dir:

--- a/doc/operation.md
+++ b/doc/operation.md
@@ -31,29 +31,30 @@ threshold binaries provided by Tom Mote. These are checked in to this repository
 Download all NSIDC-0080 granules:
 
 ```
-PYTHONPATH=. python antarctica_today/nsidc_download_Tb_data.py
+PYTHONPATH=.
+python antarctica_today/nsidc_download_Tb_data.py
 ```
 
 > :memo: Note
 >
-> For data before 2016, `NSIDC-0001` and `NSIDC-0007` are used.
+> For data before 2016, `NSIDC-0001` and `NSIDC-0007` are used. These previous data have already been processed and are available as binary ".bin" files in the **/data/daily_melt_bin_files** directory. All new data are be caculated from the NSIDC-0080 "Near Real-Time DMSP SSM/SSMIS Daily Polar Gridded Brightness Temperature" product (https://nsidc.org/data/nsidc-0080/versions/2).
 >
 > 🛠️ _TODO_
 >
-> - [ ] Does this mean we need to download 0001 and 0007 too to initialize the db?
 > - [ ] Add functionality to CLI if needed.
 
 
 ## 2. Generate all the daily melt binary files
 
 ```
-PYTHONPATH=. python antarctica_today/generate_daily_melt_file.py
+PYTHONPATH=.
+python antarctica_today/generate_daily_melt_file.py
 ```
 
 > :memo: Note
 >
 > Binaries provided in `data/daily_melt_bin_files` already calibrated by
-> Tom Mote for pre 2016 dates.
+> Tom Mote for pre 2016 dates. This generates new daily melt files from the NSIDC-0080 data downloaded in the previous step.
 >
 > 🛠️ _TODO_
 >
@@ -62,15 +63,19 @@ PYTHONPATH=. python antarctica_today/generate_daily_melt_file.py
 
 ## 3. Generate the database
 
-This software manages a database covering the full climatology in the form of a pickle
-file.
+This software manages a database covering the full climatology in the form of a pickle file.
 
 
-> TODO: ?is this as simple as:
+> TODO: This this as simple as:
 >
 > ```
-> PYTHONPATH=. python antarctica_today/main.py preprocess
+> PYTHONPATH=.
+> python antarctica_today/main.py preprocess
 > ```
+> 
+> 🛠️ _TODO_
+> 
+> - [ ] Convert from storage via picklefiles to NetCDF. See issue https://github.com/nsidc/Antarctica_Today/issues/19
 
 
 ### Initializing
@@ -83,18 +88,24 @@ file.
 Create the melt array picklefile, a file containing a 2d grid for each day:
 
 ```
-PYTHONPATH=. python antarctica_today/melt_array_picklefile.py
+PYTHONPATH=.
+python antarctica_today/melt_array_picklefile.py
 ```
 
-Create a gap filled melt picklefile, (TODO: What is it?):
-
+Create a gap-filled melt picklefile, This "fills the gaps" of missing data or missing days in the historical record with climatological averages. This is especially prevalent in the 1980s when composites are only tallied every other day. In the small 'pole hole' orbital gap, "no melt" (1) is filled. (NOTE: This assumption may need to be changed if melt ever reaches South Pole.)
 ```
-PYTHONPATH=. python antarctica_today/generate_gap_filled_melt_picklefile.py
+PYTHONPATH=.
+python antarctica_today/generate_gap_filled_melt_picklefile.py
 ```
 
 
 ### Daily updates
-
+This step will download any new Tb data files from NSIDC since its last run, and generate new plots from the last day's data (for all of Antartica and for each individual region), including:
+1) A "daily melt" map of the most recent day's melt extent
+2) A "sum" map of that season's total melt days
+3) An "anomaly" map of that season's total melt days in comparison to baseline average values to-that-day-of-year
+4) A line plot of melt extent up do that date, compared to historical baseline averages.
+It will copy these plots into a sub-directory /plots/daily_plots_gathered/[date]/ for easy collection.
 > 🛠️ _TODO_
 >
 > - [ ] Simpler command, shouldn't have to know to set PYTHONPATH.
@@ -105,14 +116,18 @@ PYTHONPATH=. python antarctica_today/generate_gap_filled_melt_picklefile.py
 > All initialization steps above must be completed first.
 
 ```
-PYTHONPATH=. python antarctica_today/update_data.py
+PYTHONPATH=.
+python antarctica_today/update_data.py
 ```
 
 
 ## 4. Generate outputs
+(Optional.)
 
+This will go through the entire database and produce summary maps and plots for every year on record.
 Run the main CLI's `process` command.
 
 ```
-PYTHONPATH=. python antarctica_today/main.py process
+PYTHONPATH=.
+python antarctica_today/main.py process
 ```


### PR DESCRIPTION
- Updated "update_data.py" to work with nsidc-0080 **v2** data.
- Created a **generate_plots_for_given_day.py** script to allow plots to be generated for any past day in the time-series without making any changes to the underlying database. This is a bit different than "update_data.py", which downloads & updates the database and then generates new plots for whatever the "latest" day is only, but does not explicitly allow generation of plots for previous days. (This allowed me to go back and generate end-of-year plots for the last day of the previous melt season, for instance).

<!-- Thank you for opening a PR! Please conform to the checklist below. If your PR is
not completely ready yet, please open a "draft" PR. -->

## PR checklist

- [ ] Has a descriptive title
- [ ] Has a descriptive body
- [ ] Passes checks (to auto-fix a pre-commit.ci failure, add a comment
      containing "pre-commit.ci autofix")
